### PR TITLE
Return rejected promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ function opengraphio (options){
           callback(err);
         }
         else{
-          Promise.reject(err);
+          return Promise.reject(err);
         }
       });
   };


### PR DESCRIPTION
Just throwing the error causes the following error in at least node `v8.1.4`:
```
(node:15749) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): StatusCodeError: 500 - {"error":"Testing error"}
(node:15749) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
even if you are catching the results of `getSiteInfo`.  Returning the rejected promise fixes that error while still allowing code that calls `getSiteInfo` to `.catch()` its results properly.